### PR TITLE
RegisterUseCaseの引数で受け取る型をLoginUseCaseに揃えた

### DIFF
--- a/template/app/src/main/java/com/dmm/bootcamp/yatter2025/usecase/impl/register/RegisterUserUseCaseImpl.kt
+++ b/template/app/src/main/java/com/dmm/bootcamp/yatter2025/usecase/impl/register/RegisterUserUseCaseImpl.kt
@@ -14,25 +14,17 @@ class RegisterUserUseCaseImpl(
   private val loginService: LoginService,
 ) : RegisterUserUseCase {
   override suspend fun execute(
-    username: String,
-    password: String,
+    username: Username,
+    password: Password,
   ): RegisterUserUseCaseResult {
-    if (username == "") {
-      return RegisterUserUseCaseResult.Failure.EmptyUsername
-    }
-    if (password == "") {
-      return RegisterUserUseCaseResult.Failure.EmptyPassword
-    }
-    val newUsername = Username(username)
-    val newPassword = Password(password)
-    if (!newPassword.validate()) {
-      return RegisterUserUseCaseResult.Failure.InvalidPassword
-    }
+    if (username.value.isBlank()) return RegisterUserUseCaseResult.Failure.EmptyUsername
+    if (password.value.isBlank()) return RegisterUserUseCaseResult.Failure.EmptyPassword
+    if (!password.validate()) return RegisterUserUseCaseResult.Failure.InvalidPassword
 
     runCatching {
       val me = userRepository.create(
-        newUsername,
-        newPassword,
+        username,
+        password,
       )
       loginUserPreferences.putUsername(me.username.value)
     }.onFailure {
@@ -41,8 +33,8 @@ class RegisterUserUseCaseImpl(
 
     runCatching {
       loginService.execute(
-        newUsername,
-        newPassword,
+        username,
+        password,
       )
     }.onFailure {
       return RegisterUserUseCaseResult.Failure.LoginError(it)

--- a/template/app/src/main/java/com/dmm/bootcamp/yatter2025/usecase/register/RegisterUserUseCase.kt
+++ b/template/app/src/main/java/com/dmm/bootcamp/yatter2025/usecase/register/RegisterUserUseCase.kt
@@ -1,8 +1,11 @@
 package com.dmm.bootcamp.yatter2025.usecase.register
 
+import com.dmm.bootcamp.yatter2025.domain.model.Password
+import com.dmm.bootcamp.yatter2025.domain.model.Username
+
 interface RegisterUserUseCase {
   suspend fun execute(
-    username: String,
-    password: String
+    username: Username,
+    password: Password,
   ): RegisterUserUseCaseResult
 }


### PR DESCRIPTION
新規登録画面の実装はログイン画面を参考にして実装するが、UseCaseで受け取る型が異なっていたので、LoginUseCase側に揃えました。